### PR TITLE
Clarified docs and fixed JSON

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -2,7 +2,9 @@
 
 <img src="https://travis-ci.org/mattly/metalsmith-placeholder.svg" data-bindattr-818="818" title="Build Status Images">
 
-A metalsmith plugin to allow stub metadata files, such as `index.html.yaml`.
+A metalsmith plugin to allow stub metadata files, such as `index.html.yaml`. The plugin parses files having extension `.yml`, `.yaml`, and `.json`, strips this extension from metalsmith's representation of the file, and replaces the file's unparsed data with the parsed data in the form of per-file metadata. The contents (buffer) of the resulting pipeline file is an empty string.
+
+The implementation requires support for ES6.
 
 ## Usage
 

--- a/src/placeholder.es6
+++ b/src/placeholder.es6
@@ -12,10 +12,10 @@ export default function(config) {
         , metadata
       ;
       try {
-        if (extName.match(/\.yaml?/)) {
+        if (extName.match(/\.ya?ml/)) {
           metadata = yaml.safeLoad( page.contents.toString() );
-        } else if (extName == 'json') {
-          metadata = JSON.stringify(page.contents.toString());
+        } else if (extName == '.json') {
+          metadata = JSON.parse(page.contents.toString());
         }
       }
       catch(e) { done(e); }


### PR DESCRIPTION
Clarified docs, fixed failure to parse JSON, fixed failure to recognize extension .yml. Addresses issue #2.

I couldn't make sense of what this plugin was supposed to do by reading the docs, so I figure that to incline others to use the plugin, the description should be a little more specific.
