### PR TITLE
Fix JSON parsing

### DIFF
--- a/src/placeholder.es6
+++ b/src/placeholder.es6
@@ -12,10 +12,10 @@ export default function(config) {
         , metadata
       ;
       try {
-        if (extName.match(/\.yaml?/)) {
+        if (extName.match(/\.ya?ml$/)) {
           metadata = yaml.safeLoad( page.contents.toString() );
-        } else if (extName == 'json') {
-          metadata = JSON.stringify(page.contents.toString());
+        } else if (extName == '.json') {
+          metadata = JSON.parse(page.contents.toString());
         }
       }
       catch(e) { done(e); }


### PR DESCRIPTION
extName has the dot "." prefix (as your yaml condition indicates), and you need to parse the JSON, not stringify it.  I also added better yaml extension handling.